### PR TITLE
Call url() with suitable options when generating $url from field_link

### DIFF
--- a/templates/node----carousel-item.tpl.php
+++ b/templates/node----carousel-item.tpl.php
@@ -1,7 +1,10 @@
 <?php
 
 if (array_key_exists('field_link', $content)):
-  $url = $content['field_link']['#items'][0]['url'];
+  # following link.module's implementation of theme_link_formatter_link_plain
+  # otherwise e.g. query params get stripped
+  $link_element = $content['field_link'][0]['#element'];
+  $url = url($link_element['url'], $link_element);
 else:
   $url = ($type == 'homepage_carousel') ? NULL : $node_url;
 endif;


### PR DESCRIPTION
This follows the code in theme_link_formatter_link_plain() from
link.module. When the raw internal 'url' property is simply
printed, it leads to any query parameters being stripped (and I'm
assuming e.g. that URL fragments are similarly missed off) because
of the internals of how Link sanitizes URLs.

This e.g. makes it impossible to have a carousel item linking to
a YouTube video.

NB I don't directly use the cambridge_carousel module, instead using a similar module for local purposes. However, this PR is a straight copy/paste from the change I've just deployed to my module (https://gitlab.developers.cam.ac.uk/ch/co/drupal-chem/chemistry_slideshow/-/commit/31fc72621907bac460380aeb1253b8819778f3fe)